### PR TITLE
Pass wasm-buffer to importHook()

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ rust({
     watchPatterns: ["src/**"],
 
     // Allows you to customize the behavior for loading the .wasm file, this is for advanced users only!
-    importHook: function (path) { return JSON.stringify(path); },
+    importHook: function (path, buffer) { return JSON.stringify(path); },
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ async function wasm_pack(cx, dir, source, id, options) {
     // TODO better way to generate the path
     const import_path = JSON.stringify("./" + posixPath($path.relative(dir, $path.join(out_dir, "index.js"))));
 
-    const import_wasm = options.importHook(options.serverPath + wasm_name);
+    const import_wasm = options.importHook(options.serverPath + wasm_name, wasm);
 
     const is_entry = cx.getModuleInfo(id).isEntry;
 
@@ -230,7 +230,7 @@ module.exports = function rust(options = {}) {
     }
 
     if (options.importHook == null) {
-        options.importHook = function (path) { return JSON.stringify(path); };
+        options.importHook = function (path, _buffer) { return JSON.stringify(path); };
     }
 
     // TODO use output.assetFileNames


### PR DESCRIPTION
I wanted to inline the WASM file as a byte array into the JavaScript.

By passing the WASM file contents to `importHook()` I could make it work like this:
```js
importHook: function (path, buffer) {
  let array = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
  return `Uint8Array.from([${array.toString()}])`
},
```
I guess thanks to your changes in https://github.com/rustwasm/wasm-bindgen/pull/1996.

Wdyt about adding this parameter to importHook()?