### PR TITLE
Fix debug config when using rollup 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,7 +350,7 @@ module.exports = function rust(options = {}) {
         name: "rust",
 
         buildStart(rollup) {
-            if (rollup.watch) {
+            if (this.meta.watchMode || rollup.watch) {
                 if (options.watch == null) {
                     options.watch = true;
                 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@wasm-tool/rollup-plugin-rust",
   "author": "Pauan <pauanyu+github@pm.me>",
   "description": "Rollup plugin for bundling and importing Rust crates.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "repository": "github:wasm-tool/rollup-plugin-rust",
   "homepage": "https://github.com/wasm-tool/rollup-plugin-rust#readme",


### PR DESCRIPTION
Hello,

This is a fix to ensure the `options.watch` & `options.debug` variables are set correctly when using rollup 2 and passing in the `--watch` flag. 

Paul

