### PR TITLE
Updated to wasm-pack 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "rimraf": "^3.0.0",
     "rollup-pluginutils": "^2.8.2",
     "toml": "^3.0.0",
-    "wasm-pack": "^0.9.0"
+    "wasm-pack": "^0.10.0"
   }
 }


### PR DESCRIPTION
Resolves security issue from rustwasm/wasm-pack#958.

I tested this in the examples directory (and left the relative path file dependency).