### PR TITLE
Add ability to run on Apple silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ package-lock.json
 yarn-error.log
 /typescript
 /example-multi
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ rust({
     importHook: function (path) { return JSON.stringify(path); },
 
     // Allows you to define a custom path to wasm-pack.
-    // Use of a '~' prefix will be converted to `os.homedir()`
-    wasmPackPath: "~/.cargo/bin/wasm-pack"
+    // If the path starts with '~' it will be converted to `os.homedir()`
+    // eg. "~/.cargo/bin/wasm-pack -> "/Users/user_name/.cargo/bin/wasm-pack"
+    wasmPackPath: "node_modules/.bin/wasm-pack"
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ rust({
 
     // Allows you to customize the behavior for loading the .wasm file, this is for advanced users only!
     importHook: function (path) { return JSON.stringify(path); },
+
+    // Allows you to define a custom path to wasm-pack.
+    // Use of a '~' prefix will be converted to `os.homedir()`
+    wasmPackPath: "~/.cargo/bin/wasm-pack"
 })
 ```
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -14,4 +14,6 @@ console_error_panic_hook = "0.1.6"
 
 [dependencies.web-sys]
 version = "0.3.35"
-features = ["console"]
+features = [
+    "console"
+]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -14,6 +14,4 @@ console_error_panic_hook = "0.1.6"
 
 [dependencies.web-sys]
 version = "0.3.35"
-features = [
-    "console",
-]
+features = ["console"]

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf dist/js && rollup --config"
   },
   "devDependencies": {
-    "@wasm-tool/rollup-plugin-rust": "file:../",
+    "@wasm-tool/rollup-plugin-rust": "^1.0.0",
     "rimraf": "^3.0.2",
     "rollup": "^1.31.0"
   }

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf dist/js && rollup --config"
   },
   "devDependencies": {
-    "@wasm-tool/rollup-plugin-rust": "^1.0.0",
+    "@wasm-tool/rollup-plugin-rust": "file:../",
     "rimraf": "^3.0.2",
     "rollup": "^1.31.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "rimraf": "^3.0.0",
     "rollup-pluginutils": "^2.8.2",
     "toml": "^3.0.0",
+    "os": "^0.1.2"
+  },
+  "optionalDependencies": {
     "wasm-pack": "^0.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@wasm-tool/rollup-plugin-rust",
   "author": "Pauan <pauanyu+github@pm.me>",
   "description": "Rollup plugin for bundling and importing Rust crates.",
-  "version": "1.0.8",
+  "version": "1.0.7",
   "license": "MIT",
   "repository": "github:wasm-tool/rollup-plugin-rust",
   "homepage": "https://github.com/wasm-tool/rollup-plugin-rust#readme",
@@ -25,8 +25,7 @@
     "glob": "^7.1.6",
     "rimraf": "^3.0.0",
     "rollup-pluginutils": "^2.8.2",
-    "toml": "^3.0.0",
-    "os": "^0.1.2"
+    "toml": "^3.0.0"
   },
   "optionalDependencies": {
     "wasm-pack": "^0.10.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@wasm-tool/rollup-plugin-rust",
   "author": "Pauan <pauanyu+github@pm.me>",
   "description": "Rollup plugin for bundling and importing Rust crates.",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "repository": "github:wasm-tool/rollup-plugin-rust",
   "homepage": "https://github.com/wasm-tool/rollup-plugin-rust#readme",


### PR DESCRIPTION
Hi,

This allows the use of the plugin on macOS with Apple silicon and addresses #24. While the issue has nothing to do with this package (the cause is the wasm-pack npm package will throw on macOS unless `arch === "x64"`), it provides a work around where the user can use their local installation of `wasm-pack`.

One thing to also note is the following exception that throws `Error: no prebuilt wasm-opt binaries are available for this platform: Unrecognized target!`. However this can also be fixed by adding the following in the `Cargo.toml`:

```toml
[package.metadata.wasm-pack.profile.release]
wasm-opt = false

[package.metadata.wasm-pack.profile.dev]
wasm-opt = false
```