### PR TITLE
Fix is_fake_id detection on Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -344,7 +344,7 @@ function is_fake_id(id, importer) {
             return true;
 
         // TODO make this faster somehow ?
-        } else if (id[0] === "." && importer.includes("/.__rollup-plugin-rust__")) {
+        } else if (id[0] === "." && importer.includes($path.sep + ".__rollup-plugin-rust__")) {
             return true;
         }
     }


### PR DESCRIPTION
Running rollup on Windows 11 it wants to pass backslashes instead of forward slashes, so these fake ids were not being detected. Example path on windows for the `importer` var `C:\Users\MyUser\code\myapp\.__rollup-plugin-rust__myapp\index.js`, and `id` `./snippets/dominator-6ffd21be2decb054/inline0.js`. It's not even consistent between the two (id being referenced directly from the index.js import), so you may want to just drop detection of a preceding slash entirely and avoid the pain.