### PR TITLE
Always make it possible to export everything

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,15 +187,7 @@ async function build(cx, state, id, options) {
 
 
 function compile_js_inline(options, import_path, real_path, wasm, is_entry) {
-    let export_code;
-
-    if (!is_entry && options.experimental.directExports) {
-        export_code = `export * from ${import_path};`;
-
-    } else {
-        export_code = "";
-    }
-
+    let export_code = `export * from ${import_path};`;
 
     let main_code;
     let sideEffects;
@@ -329,13 +321,8 @@ function compile_js_load(cx, state, options, import_path, real_path, name, wasm,
     }
 
 
-    let export_code = "";
 
-    if (!is_entry && options.experimental.directExports) {
-        export_code = `export * from ${import_path};`;
-    }
-
-
+    let export_code = `export * from ${import_path};`;
     let main_code;
     let sideEffects;
 


### PR DESCRIPTION
`wasm-bindgen` by default exports everything. There is no reason to disallow this, since the `input` of `rollup` ultimately decides what exactly should be exported.

Currently, it is required to always specify `exports`:
```typescript
import wasm from "./path/to/Cargo.toml";

async function loadWasm() {
  const exports = await wasm();
  const someClass = new exports.SomeClass();
}
```

But one should be able to do:
```typescript
import wasm, { SomeClass } from "./path/to/Cargo.toml";

async function loadWasm() {
  const exports = await wasm();
  const someClass = new SomeClass();
}
```

This behavior is currently only supported by turning on `directExport` in the experimental settings. Unfortunately, this requires `top-level await` which could not be desirable.