### PR TITLE
Replace TOML parser to support dotted keys in cargo.toml

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "wasm-pack"
   ],
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "@rollup/pluginutils": "^5.0.2",
     "binaryen": "^111.0.0",
     "chalk": "^4.0.0",
     "glob": "^10.2.2",
     "node-fetch": "^2.0.0",
     "rimraf": "^5.0.0",
-    "tar": "^6.1.11",
-    "toml": "^3.0.0"
+    "tar": "^6.1.11"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const $path = require("path");
-const $toml = require("toml");
+const $toml = require("@iarna/toml");
 const { createFilter } = require("@rollup/pluginutils");
 const { glob, rm, mv, mkdir, read, readString, writeString, exec, spawn, lock, debug, getEnv } = require("./utils");
 const { run_wasm_bindgen } = require("./wasm-bindgen");

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -3,3 +3,7 @@ members = [
     "src/bar",
     "src/foo",
 ]
+resolver = "2"
+
+[workspace.package]
+edition = "2018"

--- a/tests/src/bar/Cargo.toml
+++ b/tests/src/bar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bar"
 version = "0.1.0"
 authors = ["You <you@example.com>"]
-edition = "2018"
+edition.workspace = true
 categories = ["wasm"]
 
 [lib]

--- a/tests/src/foo/Cargo.toml
+++ b/tests/src/foo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "foo"
 version = "0.1.0"
 authors = ["You <you@example.com>"]
-edition = "2018"
+edition.workspace = true
 categories = ["wasm"]
 
 [lib]


### PR DESCRIPTION
https://github.com/BinaryMuse/toml-node does not support dotted keys, see https://github.com/BinaryMuse/toml-node/issues/51 , giving issues like this:

`[!] (plugin rust) SyntaxError: Could not load /home/eg/src/neo-mk2/app/webui/Cargo.toml?rollup-plugin-rust-entry: Expected "=", [ \t] or [A-Za-z0-9_\-] but "." found.`

when using any dotted keys in Cargo.toml.

This fix is more or less the same as https://github.com/cloudflare/miniflare/pull/13 